### PR TITLE
New line after error message output

### DIFF
--- a/phploy
+++ b/phploy
@@ -20,7 +20,7 @@ try {
     $phploy = new PHPloy();
 } catch (Exception $e) {
     // Display the error in red
-    echo Ansi::tagsToColors("\r\n<red>Oh Snap: {$e->getMessage()}");
+    echo Ansi::tagsToColors("\r\n<red>Oh Snap: {$e->getMessage()}\r\n");
 }
 
 /**


### PR DESCRIPTION
Just a little annoyance that after an error message, my command prompt isn't on a new line
