### PR TITLE
Made PHPloy version header more prominent

### DIFF
--- a/phploy
+++ b/phploy
@@ -191,7 +191,10 @@ class PHPloy
     {
         $this->parseOptions();
 
-        $this->output("\r\n-------------- phploy v{$this->phployVersion} ----------------\r\n");
+        $this->output("\r\n<bgGreen>---------------------------------------------------");
+        $this->output("<bgGreen>|              phploy v{$this->phployVersion}                |");
+        $this->output("<bgGreen>---------------------------------------------------<reset>\r\n");
+
 
         if ($this->displayHelp) {
             $this->displayHelp();
@@ -571,7 +574,7 @@ class PHPloy
             }
             if (!$this->listFiles) {
                 $this->output("\r\n<darkGreen>------ Deployment complete ------");
-                $this->output("<darkGreen>------ Deployment size: ".$this->humanFilesize($this->deploymentSize)." ------");
+                $this->output("<darkGreen>------ Deployment size: ".$this->humanFilesize($this->deploymentSize)." ------\r\n");
                 $this->deploymentSize = 0;
             }
 


### PR DESCRIPTION
Makes it easier to see where deployments started when scrolling back through long console output

_ignore the time output, that's just something I was playing with_

![screen-shot-2014-08-09-at-09 49 05](https://cloud.githubusercontent.com/assets/340752/3865666/090bd248-1fa3-11e4-9467-64880a491646.png)
