### PR TITLE
Added code to detect a default server configuration. 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ The first time it's executed, PHPloy will assume that your deployment server is 
 
 PHPloy allows you to configure multiple servers in the deploy file and deploy to any of them with ease. 
 
-By default PHPloy will deploy to *ALL* specified servers.  To specify one single server, run:
+By default PHPloy will deploy to *ALL* specified servers.  Alternatively, if an entry named 'default' exists in your server configuration, PHPloy will default to that server configuration. To specify one single server, run:
 
     phploy -s servername
 
@@ -98,6 +98,9 @@ or:
     
 `servername` stands for the name you have given to the server in the `deploy.ini` configuration file.
 
+If you have a 'default' server configured, you can specify to deploy to all configured servers by running:
+
+    phploy --all
 
 ## Rollbacks
 


### PR DESCRIPTION
If a server named default exists, PHPloy will deploy only to that server if no server is specified on the command line. Also added a --all flag to deploy to all configured servers (unless a server is also specified). Along with adding relative documentation