### PR TITLE
fixes #106 -> Fails when deleting a file that does not exist on remote

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -911,10 +911,14 @@ class PHPloy
         foreach ($filesToDelete as $fileNo => $file) {
             
             $numberOfFilesToDelete = count($filesToDelete);
-            
-            $this->connection->rm($file);
-            $fileNo = str_pad(++$fileNo, strlen($numberOfFilesToDelete), ' ', STR_PAD_LEFT);
-            $this->output("<red>removed $fileNo of $numberOfFilesToDelete <white>{$file}");
+            if($this->connection->exists($file)){
+                $this->connection->rm($file);
+                $fileNo = str_pad(++$fileNo, strlen($numberOfFilesToDelete), ' ', STR_PAD_LEFT);
+                $this->output("<red>removed $fileNo of $numberOfFilesToDelete <white>{$file}");
+            }else{
+                $fileNo = str_pad(++$fileNo, strlen($numberOfFilesToDelete), ' ', STR_PAD_LEFT);
+                $this->output("<red>not found $fileNo of $numberOfFilesToDelete <white>{$file}");
+            }
         }
 
         // Upload Files


### PR DESCRIPTION
It writes to the screen "not found" if the file being deleted is not existent on the FTP server.