### PR TITLE
About the way git-diff is used

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -676,7 +676,7 @@ class PHPloy
         } elseif (empty($remoteRevision)) {
             $command = '-c core.quotepath=false ls-files';
         } else if ($localRevision === 'HEAD') {
-            $command = '-c core.quotepath=false diff --name-status '.$remoteRevision.'...'.$localRevision;
+            $command = '-c core.quotepath=false diff --name-status '.$remoteRevision.'..'.$localRevision;
         } else {
             $command = '-c core.quotepath=false diff --name-status '.$remoteRevision.'... '.$localRevision;
         }


### PR DESCRIPTION
I have two branches, `live` for production and hotfixes and `dev` for development.
`dev` is always ahead of `live` and also gets all hotfixes merged in.

Once i deploy `dev` on a server i can no longer deploy `live`:

```sh
# fresh server (empty)
git checkout live
phploy -s # works

git checkout dev
phploy -s # works

git checkout live
phploy -s # "No files to upload"
```
But there are differences from `dev` to `live`.

I tried the `--debug` switch and noticed that the symmetric difference notation was used with `git-diff` (the three dots). like `git diff <remote-commit>...HEAD` which was not what i expected.
So i changed it to make use of the difference between `<remote-commit>` and `HEAD` instead of the set of commits that are reachable from either one of `<remote-commit>` or `HEAD` but not from both ([reference](http://git-scm.com/docs/git-rev-parse)).

and suddenly I have no need for '--rollback' anymore. because this also works now:

```sh
git checkout @^
phploy -s 
```
Which is in my opinion a more intuitive approach as `--rollback`.

This fixes my case but i'm not sure if problems are introduced anywhere else - Mainly because I don't know why the symmetric difference notation exists and I never saw a use case for it which i could comprehend... 

Do you still remember why you chose the 3 dots over a space back in Feb 2014 ?