### PR TITLE
Fix issues with the directory deletion check

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -1161,8 +1161,8 @@ class PHPloy
         foreach ($filesToDelete as $file) {
         
             // Break directories into a list of items
-            $parts = split("/", $file);
             
+            $parts = explode("/", $file);
             // Remove files name from the list
             array_pop($parts);
             
@@ -1178,7 +1178,7 @@ class PHPloy
                 
                 // Check of directory exits. If it doesn't exist
                 // Add it to the list if files to delete
-                if( ! is_dir($part) ) {
+                if( is_dir($part) && count(glob($part . "/*")) === 0 ) {
                     $dirsToDelete[] = $part;
                 }                
             }


### PR DESCRIPTION
Currently the directory deletion check throws deprecated errors due to the use of split() and tries to delete non-empty parent directories. This will look at the files directory and delete it all without throwing deprecated errors.

This addresses #153 with a caveat in that it doesn't recursively check parent directories for empty. It does however prevent issues caused by the current incarnation of the script.