### PR TITLE
4.0 - skip adding the other servers during server preparation if a server is specified

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -342,6 +342,12 @@ class PHPloy
         $servers = $this->parseCredentials($iniFile);
 
         foreach ($servers as $name => $options) {
+            
+            // If a server is specified, we can skip adding the others
+            if ($this->server != '' && $this->server != $name) {
+                continue;
+            }
+            
             $options = array_merge($defaults, $options);
 
             // Determine if a default server is configured


### PR DESCRIPTION
I have two staging servers and one prod server, where I don't store the password to keep it out of version control. When I deploy to a staging server via `--server` I see the message `No password has been provided for user "exampl_prod_user". Please enter a password:`. Then I hit enter and it works fine. This message just shouldn't pop up, because I don't deploy to this server... The PR should fix this.