### PR TITLE
Fix wrong check for result of file_get_contents

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -805,7 +805,7 @@ class PHPloy
                 $data = @file_get_contents($filePath);
 
                 // It can happen the path is wrong, especially with included files.
-                if (!$data) {
+                if ($data === FALSE) {
                     $this->cli->error(' ! File not found - please check path: '.$filePath);
                     continue;
                 }


### PR DESCRIPTION
Fix #220. Return value of file_get_contents was just negated.
But in PHP, the empty string or even the string "0" are FALSE,
too. So reading of 0-byte files or files only containing "0"
also evaluated to FALSE, triggering a misleading "file not
readable" error message. Check is now done as "=== FALSE" to
catch all corner cases.

See also http://php.net/manual/en/function.file-get-contents.php
section "Return Values" (WARNING box) and
http://php.net/manual/en/language.types.boolean.php section
"Converting to boolean".