### PR TITLE
Fixes the listing of the current directory

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -1133,8 +1133,8 @@ class PHPloy
             }
             $this->cli->out("<red>Copying directory <white>{$fromDir}<red> to <white>{$toDir}");
 
-            // Recursive file/dir listing
-            $contents = $this->connection->listContents($fromDir, true);
+            // File/dir listing
+            $contents = $this->connection->listContents($fromDir, false);
 
             if (count($contents) < 1) {
                 $this->cli->out(" - Nothing to copy in {$fromDir}");


### PR DESCRIPTION
When I copy directory, files has been copied to the directory and to the root...

```
Copying directory site/www to staging/www
 * site/www/.htaccess is copied to staging/www/.htaccess
 * site/www/index.php is copied to staging/www/index.php
Copied site/www to staging/www
 * site/www/.htaccess is copied to staging/.htaccess
 * site/www/index.php is copied to staging/index.php
```

The bug was that all files are listed recursively, and when we enter in a directory, we list again.