### PR TITLE
Add support for using ftp options in environment variables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ The `phploy.ini` file holds your project configuration. It should be located in 
     post-deploy[] = "wget http://staging-example.com/post-deploy/test.php --spider --quiet"
 ```
 
-If your password is missing in the `phploy.ini` file, PHPloy will interactively ask you for your password.
+If your password is missing in the `phploy.ini` file or the `PHPLOY_PASSWORD` environment variable, PHPloy will interactively ask you for your password.
 There is also an option to store the password in a file called `.phploy`.
 
 ```
@@ -99,6 +99,29 @@ There is also an option to store the password in a file called `.phploy`.
 ```
 
 This feature is especially useful if you would like to share your phploy.ini via Git but hide your password from the public.
+
+You can also use environment variables to deploy without storing your credentials in a file.
+These variables will be used if they do not exist in the `phploy.ini` file:
+```
+PHPLOY_HOST
+PHPLOY_PORT
+PHPLOY_PASSWORD
+PHPLOY_USER
+```
+
+These variables can be used like this;
+```
+$ PHPLOY_PORT="21" PHPLOY_HOST="myftphost.com" PHPLOY_USER="ftp" PHPLOY_PASSWORD="ftp-password" phploy -s servername
+```
+
+Or export them like this, the script will automatically use them:
+```
+$ export PHPLOY_PORT="21"
+$ export PHPLOY_HOST="myftphost.com"
+$ export PHPLOY_USER="ftp"
+$ export PHPLOY_PASSWORD="ftp-password"
+$ phploy -s servername
+```
 
 ## Multiple servers
 

--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -433,11 +433,28 @@ class PHPloy
                 $this->postDeployRemote[$name] = $servers[$name]['post-deploy-remote'];
             }
 
+            // Set host from environment variable if it does not exist in the config
+            if (empty($options['host']) && !empty(getenv('PHPLOY_HOST'))) {
+                $options['host'] = getenv('PHPLOY_HOST');
+            }
+
+            // Set port number from environment variable if it does not exist in the config
+            if (empty($options['port']) && !empty(getenv('PHPLOY_PORT'))) {
+                $options['port'] = getenv('PHPLOY_PORT');
+            }
+
+            // Set username from environment variable if it does not exist in the config
+            if (empty($options['user']) && !empty(getenv('PHPLOY_USER'))) {
+                $options['user'] = getenv('PHPLOY_USER');
+            }
+
            // Ask for a password if it is empty and a private key is not provided
             if ($options['pass'] === '' && $options['privkey'] === '') {
                 // Look for .phploy config file
                 if (file_exists($this->getPasswordFile())) {
                     $options['pass'] = $this->getPasswordFromIniFile($name);
+                } elseif (!empty(getenv('PHPLOY_PASSWORD'))) {
+                    $options['pass'] = getenv('PHPLOY_PASSWORD');
                 } else {
                     fwrite(STDOUT, 'No password has been provided for user "'.$options['user'].'". Please enter a password: ');
                     $options['pass'] = $this->getPassword();


### PR DESCRIPTION
I was surprised to find that this feature didn't exist, so I implemented it :).
This can be useful for deploying with Gitlab for example, in which you can set specific environment variables for a built process in a projects' configuration. This way you won't have to store them in any files making it a bit more secure and easier to use.