### PR TITLE
Update call to have a ready to go initial setup

### DIFF
--- a/phploy.bat
+++ b/phploy.bat
@@ -1,5 +1,5 @@
 :: To run phploy globally (from any folder), either add this folder to your system's PATH
-:: or copy this BAT file somewhere into your system's PATH, eg. C:\WINDOWS
+:: or copy and edit this BAT file somewhere into your system's PATH, eg. C:\WINDOWS
 ::
 :: Note you will need PHP.exe somewhere on your system also, and if it's not also
 :: in your PATH variable, you will need to specify the full path to it below
@@ -17,4 +17,10 @@
 :: Set the console code page to use UTF-8
 chcp 65001 > NUL
 
-php C:\path\to\phploy %*
+:: error_reporting integer value of E_ALL & ~E_NOTICE
+for /f %%i in ('php -r "echo E_ALL & ~E_NOTICE;"') do set ER=%%i
+
+:: %~dp0 is the shell variable for the script directory, equivalent to the PHP "__DIR__" 
+:: magic constant. You can replace it with your phploy installation directory if you
+:: moved this bat file from it.
+php -d error_reporting=%ER% "%~dp0\dist\phploy.phar" %*


### PR DESCRIPTION
Also pass an error_reporting without E_NOTICE to the execution of phploy.

This should allow people to run the bat file without editing if they included the phploy directory to their path instead of moving the file.