### PR TITLE
Allowing for privkey contents to be passed

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -109,7 +109,7 @@ class Connection
                 $server['privkey'] = substr_replace($server['privkey'], getenv('HOME'), 0, 1);
             }
 
-            if (!empty($server['privkey']) && !is_file($server['privkey'])) {
+            if (!empty($server['privkey']) && !is_file($server['privkey']) && "---" !== substr($server['privkey'], 0, 3)) {
                 throw new \Exception("Private key {$server['privkey']} doesn't exists.");
             }
 


### PR DESCRIPTION
The Flysystem SFTP allows for the passing of a key contents however this validation is out of sync with the flysystem validation. This brings the validation inline to allow passing the file contents.

See: https://github.com/thephpleague/flysystem-sftp/blob/79453d7b83b608a1e7b630787d43086d5cf77351/src/SftpAdapter.php#L261