### PR TITLE
Trim the content of the .revision.

### DIFF
--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -828,7 +828,7 @@ class PHPloy
         if ($this->fresh) {
             $this->cli->out('Manual fresh upload...');
         } elseif ($this->connection->has($this->dotRevision)) {
-            $remoteRevision = $this->connection->read($this->dotRevision);
+            $remoteRevision = trim($this->connection->read($this->dotRevision));
             $this->debug('Remote revision: <bold>'.$remoteRevision);
         } else {
             $this->cli->out('No revision found. Fresh upload...');


### PR DESCRIPTION
Hi,
I'm currently migrating from [Beanstalk](https://beanstalkapp.com) to GitLab Ci and found your project helpful to easily migrate the deployment process. The only small thing is that Beanstalk adds a newline on the end of the `.revision` file. With this added trim Phploy can take over the deployment process without any `--sync`.