### PR TITLE
Stop execution on local pre deploy when there is an error

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -40,12 +40,18 @@ class Git
      * @param string $command Command to execute
      *
      * @return array of all lines that were output to the console during the command (STDOUT)
+     *
+     * @throws \Exception
      */
     public function exec($command)
     {
         $output = null;
 
-        exec('('.$command.') 2>&1', $output);
+        exec('('.$command.') 2>&1', $output, $exitcode);
+
+        if ($exitcode !== 0){
+            throw new \Exception('Command [' . $command . '] exited badly');
+        }
 
         return $output;
     }

--- a/src/Git.php
+++ b/src/Git.php
@@ -38,18 +38,19 @@ class Git
      * Executes a console command and returns the output (as an array).
      *
      * @param string $command Command to execute
+     * @param boolean $onErrorStopExecution If there is a problem, stop execution of the code
      *
      * @return array of all lines that were output to the console during the command (STDOUT)
      *
      * @throws \Exception
      */
-    public function exec($command)
+    public function exec($command, $onErrorStopExecution = false)
     {
         $output = null;
 
         exec('('.$command.') 2>&1', $output, $exitcode);
 
-        if ($exitcode !== 0){
+        if ($onErrorStopExecution && $exitcode !== 0){
             throw new \Exception('Command [' . $command . '] exited badly');
         }
 

--- a/src/PHPloy.php
+++ b/src/PHPloy.php
@@ -1470,7 +1470,7 @@ class PHPloy
         foreach ($commands as $command) {
             $this->cli->out("Execute : <white>{$command}");
 
-            $output = $this->git->exec($command);
+            $output = $this->git->exec($command, true);
 
             $output = implode("\n\r", $output);
             $this->cli->out("Result : <white>{$output}");


### PR DESCRIPTION
On a local pre-deploy command, if the exit code is
greater than 0, stop the deploy process