### PR TITLE
Update minimum required PHP version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # PHPloy
 **Version 4.9.2**
 
-PHPloy is an incremental Git FTP and SFTP deployment tool. By keeping track of the state of the remote server(s) it deploys only the files that were committed since the last deployment. PHPloy supports submodules, sub-submodules, deploying to multiple servers and rollbacks. PHPloy requires **PHP 7.0+** and **Git 1.8+**.
+PHPloy is an incremental Git FTP and SFTP deployment tool. By keeping track of the state of the remote server(s) it deploys only the files that were committed since the last deployment. PHPloy supports submodules, sub-submodules, deploying to multiple servers and rollbacks. PHPloy requires **PHP 7.3+** and **Git 1.8+**.
 
 ## How it works
 


### PR DESCRIPTION
Fixes #386 

If approved, this change will update the readme file, adjusting the required PHP version to 7.3+ as it's defined on composer.json:
https://github.com/banago/PHPloy/blob/51e242fd83794421f6520bc98130fdab815645cc/composer.json#L15
