### PR TITLE
Update composer.json with `league/flysystem-sftp-v3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.3",
         "league/climate": "^3.0",
         "league/flysystem": "^1.0",
-        "league/flysystem-sftp": "^1.0"
+        "league/flysystem-sftp-v3": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
```
Installing banago/phploy (v4.9.1): Extracting archive 2 package suggestions were added by new dependencies, use `composer suggest` to see details. 
Package league/flysystem-sftp is abandoned, you should avoid using it. 
Use league/flysystem-sftp-v3 instead. 
Generating autoload files
```

Updating this dependency. 