### PR TITLE
Add missing features to v5.x (hooks, logger, custom port + privkey)

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -212,14 +212,17 @@ class Cli
     }
 
     /**
-     * Log a deployment event
+     * Log a deployment event and optionally persist it to phploy.log.
+     *
+     * @param bool $logToFile Write the entry to phploy.log when true (logger = on in phploy.ini)
      */
     public function logDeployment(
         string $sha,
         string $server,
         string $branch,
         int $filesUploaded,
-        int $filesDeleted
+        int $filesDeleted,
+        bool $logToFile = false
     ): void {
         $message = sprintf(
             '[SHA: %s] Deployment to server: "%s" from branch "%s". %d files uploaded; %d files deleted.',
@@ -231,5 +234,27 @@ class Cli
         );
 
         $this->info($message);
+
+        if ($logToFile) {
+            $this->writeLog($message);
+        }
+    }
+
+    /**
+     * Append a log entry to phploy.log in the current working directory.
+     */
+    public function writeLog(string $message, string $type = 'INFO'): void
+    {
+        $filename = getcwd() . DIRECTORY_SEPARATOR . 'phploy.log';
+
+        if (!file_exists($filename)) {
+            touch($filename);
+        }
+
+        file_put_contents(
+            $filename,
+            date('Y-m-d H:i:sP') . ' --- ' . $type . ': ' . $message . PHP_EOL,
+            FILE_APPEND
+        );
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -100,6 +100,8 @@ class Config
             'permissions' => null,
             'directoryPerm' => 0755,
             'branch' => '',
+            'base' => '',
+            'logger' => false,
             'include' => [],
             'exclude' => array_merge($this->globalFilesToExclude, [$this->iniFile]),
             'copy' => [],
@@ -129,14 +131,17 @@ class Config
             }
         }
 
-        // Check if the quickmode URL is correct.
-        $parsed_url = parse_url($options['quickmode']);
-        if ($parsed_url === false) {
-            throw new \Exception('Your quickmode URL cannot be parsed. Please fix it.');
+        // Normalise base: must end with '/' when non-empty
+        if (!empty($config['base'])) {
+            $config['base'] = rtrim($config['base'], '/') . '/';
         }
 
-        // Merge parsed quickmode details
+        // Merge quickmode URL if present
         if (isset($options['quickmode'])) {
+            $parsed_url = parse_url($options['quickmode']);
+            if ($parsed_url === false) {
+                throw new \Exception('Your quickmode URL cannot be parsed. Please fix it.');
+            }
             $config = array_merge($config, $parsed_url);
         }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -58,6 +58,7 @@ class Connection
             'port' => $server['port'],
             'username' => $server['user'],
             'password' => $server['pass'],
+            'privkey' => $server['privkey'],
             'root' => $server['path'],
             'timeout' => ($server['timeout'] ?: 30),
             'visibility' => $server['visibility'] ?? 'public',

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -55,6 +55,7 @@ class Connection
     {
         $options = [
             'host' => $server['host'],
+            'port' => $server['port'],
             'username' => $server['user'],
             'password' => $server['pass'],
             'root' => $server['path'],

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -28,6 +28,16 @@ class Connection
     public $server;
 
     /**
+     * @var bool
+     */
+    protected $isSftp = false;
+
+    /**
+     * @var SftpConnectionProvider|null
+     */
+    protected $sftpConnectionProvider = null;
+
+    /**
      * Connection constructor.
      *
      * @param array $server
@@ -55,11 +65,11 @@ class Connection
     {
         $options = [
             'host' => $server['host'],
-            'port' => $server['port'],
             'username' => $server['user'],
             'password' => $server['pass'],
-            'privkey' => $server['privkey'],
             'root' => $server['path'],
+            'port' => $server['port'],
+            'privkey' => $server['privkey'],
             'timeout' => ($server['timeout'] ?: 30),
             'visibility' => $server['visibility'] ?? 'public',
             'permPublic' => $server['permPublic'] ?? 0644,
@@ -165,11 +175,47 @@ class Connection
                 ],
             ]);
 
+            $this->isSftp = true;
+            $this->sftpConnectionProvider = $connectionProvider;
+
             return new Filesystem(new SftpAdapter($connectionProvider, $options['root'], $visibility));
         } catch (\Exception $e) {
             echo "\r\nOh Snap: {$e->getMessage()}\r\n";
             throw $e;
         }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSftp(): bool
+    {
+        return $this->isSftp;
+    }
+
+    /**
+     * Execute a command on the remote SFTP server.
+     * Returns the command output, or throws on connection/exec failure.
+     *
+     * @param string $command
+     * @return string
+     * @throws \Exception if not an SFTP connection or exec fails
+     */
+    public function exec(string $command): string
+    {
+        if (!$this->sftpConnectionProvider) {
+            throw new \Exception('exec() is only supported for SFTP connections.');
+        }
+
+        $sftp = $this->sftpConnectionProvider->provideConnection();
+
+        $result = $sftp->exec($command);
+
+        if ($result === false) {
+            throw new \Exception("Remote command failed: {$command}");
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -237,11 +237,7 @@ class Connection
      */
     public function directoryExists($path)
     {
-        try {
-            return $this->server->directoryExists($path);
-        } catch (\Exception $e) {
-            return false;
-        }
+       return $this->server->directoryExists($path);
     }
 
     /**

--- a/src/Deployment.php
+++ b/src/Deployment.php
@@ -171,7 +171,16 @@ class Deployment
         $this->connection = new Connection($server);
         
         // Check if remote path exists
-        if (!$this->connection->directoryExists('')) {
+        try {
+            $rootExists = $this->connection->directoryExists('');
+        } catch (\Exception $e) {
+            $this->cli->error("\r\nSERVER: " . $name);
+            $this->cli->error("Could not connect to server: " . $e->getMessage());
+            $this->cli->info("Deployment skipped.");
+            return;
+        }
+
+        if (!$rootExists) {
             $this->cli->error("\r\nSERVER: " . $name);
             $this->cli->error("Remote path does not exist: " . $server['path']);
             $this->cli->info("Deployment skipped.");

--- a/src/Deployment.php
+++ b/src/Deployment.php
@@ -193,14 +193,29 @@ class Deployment
         // Get files to deploy
         $files = $this->compare();
 
+        // Apply filters from phploy.ini
+        $files = $this->filterBasePath($files);
+        $files = $this->filterExcluded($files);
+        $files = $this->filterIncluded($files);
+
         $this->cli->info("\r\nSERVER: " . $name);
 
         if ($this->listFiles) {
             $this->listFiles($files);
             $this->handleSubmodules($files);
         } else {
+            // pre-deploy (local) — failure stops the deployment
+            $this->runLocalCommands($server['pre-deploy'] ?? [], true);
+            // pre-deploy-remote (SFTP only)
+            $this->runRemoteCommands($server['pre-deploy-remote'] ?? []);
+
             $this->push($files);
             $this->handleSubmodules($files);
+
+            // post-deploy (local) — failure is logged but does not abort
+            $this->runLocalCommands($server['post-deploy'] ?? []);
+            // post-deploy-remote (SFTP only)
+            $this->runRemoteCommands($server['post-deploy-remote'] ?? []);
         }
 
         // Show deployment size
@@ -437,7 +452,8 @@ class Deployment
                 $this->currentServerName,
                 $initialBranch ?: 'master',
                 count($files['upload']),
-                count($files['delete'])
+                count($files['delete']),
+                !empty($this->currentServerInfo['logger'])
             );
         } else {
             $this->cli->info('No files to upload or delete.');
@@ -469,8 +485,10 @@ class Deployment
             return;
         }
 
+        $remoteFile = $this->removeBasePath($file);
+
         try {
-            $this->connection->put($file, $data);
+            $this->connection->put($remoteFile, $data);
             $this->deploymentSize += filesize($filePath);
 
             $fileNo = str_pad((string) $number, strlen((string) $total), ' ', STR_PAD_LEFT);
@@ -483,7 +501,7 @@ class Deployment
                 $this->connection = new Connection($this->currentServerInfo);
 
                 try {
-                    $this->connection->put($file, $data);
+                    $this->connection->put($remoteFile, $data);
                     $this->deploymentSize += filesize($filePath);
 
                     $fileNo = str_pad((string) $number, strlen((string) $total), ' ', STR_PAD_LEFT);
@@ -505,10 +523,11 @@ class Deployment
         }
 
         $fileNo = str_pad((string) $number, strlen((string) $total), ' ', STR_PAD_LEFT);
+        $remoteFile = $this->removeBasePath($file);
 
         try {
-            if ($this->connection->has($file)) {
-                $this->connection->delete($file);
+            if ($this->connection->has($remoteFile)) {
+                $this->connection->delete($remoteFile);
                 $this->cli->info(" × {$fileNo} of {$total} {$file}");
             } else {
                 $this->cli->warning(" ! {$fileNo} of {$total} {$file} not found");
@@ -612,6 +631,157 @@ class Deployment
             $this->cli->success('Files that will be uploaded in next deployment:');
             foreach ($files['upload'] as $file) {
                 $this->cli->info("   {$file}");
+            }
+        }
+    }
+
+    /**
+     * Remove files matching exclude[] patterns from both upload and delete lists.
+     * Patterns support wildcards (* and ?) and bare directory names.
+     */
+    protected function filterExcluded(array $files): array
+    {
+        $exclude = $this->currentServerInfo['exclude'] ?? [];
+
+        if (empty($exclude)) {
+            return $files;
+        }
+
+        $filter = function (string $file) use ($exclude): bool {
+            foreach ($exclude as $pattern) {
+                if (
+                    pattern_match($pattern, $file) ||
+                    pattern_match($pattern, basename($file)) ||
+                    strpos($file, rtrim($pattern, '/\\') . '/') === 0
+                ) {
+                    $this->cli->info(" - Excluded: {$file}");
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        $files['upload'] = array_values(array_filter($files['upload'], $filter));
+        $files['delete'] = array_values(array_filter($files['delete'], $filter));
+
+        return $files;
+    }
+
+    /**
+     * Restrict upload/delete lists to files that live inside the configured base path.
+     * base = 'subdir/' in phploy.ini means only files under subdir/ are deployed.
+     */
+    protected function filterBasePath(array $files): array
+    {
+        $base = $this->currentServerInfo['base'] ?? '';
+
+        if (empty($base)) {
+            return $files;
+        }
+
+        $pattern = '/^' . preg_quote($base, '/') . '/';
+
+        $files['upload'] = array_values(array_filter($files['upload'], fn($f) => preg_match($pattern, $f)));
+        $files['delete'] = array_values(array_filter($files['delete'], fn($f) => preg_match($pattern, $f)));
+
+        return $files;
+    }
+
+    /**
+     * Strip the base path prefix from a file path to obtain the remote path.
+     */
+    protected function removeBasePath(string $file): string
+    {
+        $base = $this->currentServerInfo['base'] ?? '';
+
+        if (empty($base)) {
+            return $file;
+        }
+
+        return preg_replace('/^' . preg_quote($base, '/') . '/', '', $file);
+    }
+
+    /**
+     * Add files matching include[] patterns to the upload list, regardless of git diff.
+     * Patterns support wildcards and directory names (all files inside are included).
+     */
+    protected function filterIncluded(array $files): array
+    {
+        $include = $this->currentServerInfo['include'] ?? [];
+
+        if (empty($include)) {
+            return $files;
+        }
+
+        foreach ($include as $pattern) {
+            $matches = glob($this->repo . DIRECTORY_SEPARATOR . $pattern);
+            if ($matches === false) {
+                continue;
+            }
+
+            foreach ($matches as $match) {
+                if (is_dir($match)) {
+                    $dirFiles = dir_tree($match, true, false, true);
+                    foreach ($dirFiles as $localFile) {
+                        $relFile = ltrim(str_replace([$this->repo . '/', $this->repo . '\\'], '', $localFile), '/\\');
+                        if (! in_array($relFile, $files['upload'], true)) {
+                            $files['upload'][] = $relFile;
+                        }
+                    }
+                } elseif (is_file($match)) {
+                    $relFile = ltrim(str_replace([$this->repo . '/', $this->repo . '\\'], '', $match), '/\\');
+                    if (! in_array($relFile, $files['upload'], true)) {
+                        $files['upload'][] = $relFile;
+                    }
+                }
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * Execute local shell commands (pre-deploy / post-deploy).
+     * When $failOnError is true an exception stops the deployment.
+     */
+    protected function runLocalCommands(array $commands, bool $failOnError = false): void
+    {
+        foreach ($commands as $command) {
+            $this->cli->info("$ {$command}");
+            $output = $this->git->exec($command, $failOnError);
+            foreach ($output as $line) {
+                $this->cli->info($line);
+            }
+        }
+    }
+
+    /**
+     * Execute commands on the remote server via SFTP (pre-deploy-remote / post-deploy-remote).
+     * Each command is prefixed with a cd to the deployment path.
+     */
+    protected function runRemoteCommands(array $commands): void
+    {
+        if (empty($commands)) {
+            return;
+        }
+
+        if (! $this->connection->isSftp()) {
+            $this->cli->warning('Remote commands are only supported for SFTP connections. Skipping.');
+            return;
+        }
+
+        $path = rtrim($this->currentServerInfo['path'], '/');
+
+        foreach ($commands as $command) {
+            $full = "cd {$path} && {$command}";
+            $this->cli->info("remote$ {$command}");
+            try {
+                $output = $this->connection->exec($full);
+                if ($output !== '') {
+                    $this->cli->info(rtrim($output));
+                }
+            } catch (\Exception $e) {
+                $this->cli->error('Remote command failed: ' . $e->getMessage());
             }
         }
     }


### PR DESCRIPTION
This PR adds the essential missing features in v5 including

- Hooks
- Logger
- Correct handling of custom port and privkey
- Not uploading phploy.ini (...)

Tested with PHP 8.4 and 8.5. 
PHP 8.5 leads the deprecation warnings in e.g. \league\climate\src\Argument\Manager.php but can be ignored.
